### PR TITLE
Load requests on mobile page

### DIFF
--- a/js/src/forum/components/RequestsPage.js
+++ b/js/src/forum/components/RequestsPage.js
@@ -19,6 +19,8 @@ export default class RequestsPage extends Page {
 
         app.history.push('requests');
 
+        app.usernameRequests.load();
+
         this.bodyClass = 'App--requests';
     }
 


### PR DESCRIPTION
Currently, the mobile page appears blank. This is because the call to load requests is missing.