### PR TITLE
fix: set loading to `false` when password entered incorrect

### DIFF
--- a/js/src/forum/components/RequestModal.js
+++ b/js/src/forum/components/RequestModal.js
@@ -158,6 +158,7 @@ export default class RequestModal extends Modal {
   onerror(error) {
     if (error.status === 401) {
       error.alert.content = app.translator.trans('core.forum.change_email.incorrect_password_message');
+      this.submitLoading = false;
     }
 
     super.onerror(error);


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
When password entered incorrect, `submitLoading` state still activated


**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
