### PR TITLE
fix: allow users that signed up through oauth to request username change

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -60,6 +60,9 @@ return [
         ->attribute('canRequestNickname', function (Serializer\ForumSerializer $serializer) {
             return $serializer->getActor()->hasPermission('user.requestNickname');
         })
+        ->attribute('passwordlessSignUp', function (Serializer\ForumSerializer $serializer) {
+            return !$serializer->getActor()->isGuest() && $serializer->getActor()->loginProviders()->count() > 0;
+        })
         ->hasMany('username_requests', RequestSerializer::class),
 
     (new Extend\ApiController(ShowForumController::class))

--- a/js/src/forum/components/RequestModal.js
+++ b/js/src/forum/components/RequestModal.js
@@ -68,16 +68,18 @@ export default class RequestModal extends Modal {
               disabled={this.deleteLoading || this.submitLoading}
             />
           </div>
-          <div className="Form-group">
-            <input
-              type="password"
-              name="password"
-              className="FormControl"
-              placeholder={app.translator.trans('core.forum.change_email.confirm_password_placeholder')}
-              bidi={this.password}
-              disabled={this.deleteLoading || this.submitLoading}
-            />
-          </div>
+          {app.forum.attribute('passwordlessSignUp') ? null : (
+            <div className="Form-group">
+              <input
+                type="password"
+                name="password"
+                className="FormControl"
+                placeholder={app.translator.trans('core.forum.change_email.confirm_password_placeholder')}
+                bidi={this.password}
+                disabled={this.deleteLoading || this.submitLoading}
+              />
+            </div>
+          )}
           <div className="Form-group">
             {Button.component(
               {

--- a/src/Api/Controller/CreateRequestController.php
+++ b/src/Api/Controller/CreateRequestController.php
@@ -56,7 +56,9 @@ class CreateRequestController extends AbstractCreateController
     {
         $actor = RequestUtil::getActor($request);
 
-        if (!$actor->checkPassword(Arr::get($request->getParsedBody(), 'meta.password'))) {
+        // If they signed up using a third party oauth provider, they won't have a password
+        // so we can't check it. We'll just assume they're authenticated.
+        if ($actor->loginProviders()->count() === 0 && !$actor->checkPassword(Arr::get($request->getParsedBody(), 'meta.password'))) {
             throw new NotAuthenticatedException();
         }
 


### PR DESCRIPTION
**Fixes #23**

**Changes proposed in this pull request:**
OAuth users have a random unknown password set. So password confirmation doesn't work.
This PR skips password confirmation if the actor has any oauth providers set.

**Reviewers should focus on:**
Alternative solutions could be:
* Force them to set a password instead.
* Initiate a login to one of the providers of choice as confirmation (would be very hacky).

Downsides of this PR:
* Even if they have a password set, if they have one provider, they no longer have to confirm their password.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
