### PR TITLE
fix(routing): use slug for routing on UserPage

### DIFF
--- a/js/src/forum/addProfilePage.js
+++ b/js/src/forum/addProfilePage.js
@@ -10,7 +10,7 @@ export default function () {
         'username-requests',
         LinkButton.component(
           {
-            href: app.route('username_history', { username: this.user.username() }),
+            href: app.route('username_history', { username: this.user.slug() }),
             icon: 'fas fa-user-edit',
           },
           app.translator.trans('fof-username-request.forum.user.name_history_link')


### PR DESCRIPTION
Summary:

- Use slug instead of username to ensure compatibility no matter if the slug driver is left to default or id.