### PR TITLE
feat: optional flarum/audit integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         }
     },
     "require-dev": {
-        "flarum/audit": "*",
+        "flarum/audit": "2.x-dev",
         "flarum/nicknames": "^2.0.0",
         "flarum/phpstan": "^2.0.0",
         "flarum/testing": "^2.0.0"

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         }
     },
     "require-dev": {
+        "flarum/audit": "*",
         "flarum/nicknames": "^2.0.0",
         "flarum/phpstan": "^2.0.0",
         "flarum/testing": "^2.0.0"

--- a/extend.php
+++ b/extend.php
@@ -16,6 +16,7 @@ use Flarum\Api\Resource\UserResource;
 use Flarum\Extend;
 use Flarum\User\User;
 use FoF\UserRequest\Api\Resource\UsernameRequestResource;
+use FoF\UserRequest\Audit\UsernameRequestIntegration;
 
 return [
     (new Extend\Frontend('forum'))
@@ -64,4 +65,11 @@ return [
 
     (new Extend\View())
         ->namespace('fof-username-request', __DIR__.'/resources/views'),
+
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-audit', fn () => [
+            (new \Flarum\Audit\Extend\Audit())
+                ->group('fof-username-request')
+                ->using(new UsernameRequestIntegration()),
+        ]),
 ];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -102,3 +102,17 @@ fof-username-request:
     subject:
       approved: "{display_name} approved your username change to {requested_username}"
       rejected: "{display_name} rejected your username change to {requested_username}"
+
+# Labels for the audit log entries this extension produces, rendered by the (optional)
+# flarum/audit browser. Defined under the flarum-audit namespace so the audit frontend
+# resolves them, but shipped here so they travel with the extension that owns the actions.
+flarum-audit:
+  lib:
+    browser:
+      user:
+        nickname_requested: Requested new nickname {new_nickname} for user {username}
+        nickname_request_approved: Approved {username}'s nickname change from {old_nickname} to {new_nickname}
+        nickname_request_rejected: Rejected {username}'s nickname change
+        username_requested: Requested new username {new_username} for user {username}
+        username_request_approved: Approved {username}'s username change from {old_username} to {new_username}
+        username_request_rejected: Rejected {username}'s username change

--- a/src/Audit/UsernameRequestIntegration.php
+++ b/src/Audit/UsernameRequestIntegration.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of fof/username-request.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\UserRequest\Audit;
+
+use Flarum\Audit\AuditLogger;
+use Flarum\User\User;
+use FoF\UserRequest\UsernameRequest;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+
+/**
+ * fof/username-request integration for the optional flarum/audit extension.
+ *
+ * Stateful: captures the old username/nickname on user update and reacts to the request
+ * lifecycle. Wired through the audit extender's `using()` escape hatch.
+ */
+class UsernameRequestIntegration
+{
+    /**
+     * @var string[]
+     */
+    public static $actions = [
+        'user.nickname_requested',
+        'user.nickname_request_approved',
+        'user.nickname_request_rejected',
+        'user.username_requested',
+        'user.username_request_approved',
+        'user.username_request_rejected',
+    ];
+
+    protected ?string $oldNickname = null;
+    protected ?string $oldUsername = null;
+
+    public function __invoke(Container $container): void
+    {
+        // Listen on the events dispatcher rather than the static Model::event(Closure) API, so the
+        // listeners aren't bound to the model classes' static dispatcher.
+        $events = $container->make(Dispatcher::class);
+
+        $events->listen('eloquent.updated: '.User::class, [$this, 'userUpdated']);
+        $events->listen('eloquent.saved: '.UsernameRequest::class, [$this, 'requestSaved']);
+    }
+
+    public function userUpdated(User $user): void
+    {
+        $this->oldNickname = $user->getOriginal('nickname');
+        $this->oldUsername = $user->getOriginal('username');
+    }
+
+    public function requestSaved(UsernameRequest $request): void
+    {
+        switch ($request->status) {
+            case 'Sent':
+                if ($request->for_nickname) {
+                    AuditLogger::log('user.nickname_requested', [
+                        'user_id'      => $request->user_id,
+                        'new_nickname' => $request->requested_username ?: null,
+                    ]);
+                } else {
+                    AuditLogger::log('user.username_requested', [
+                        'user_id'      => $request->user_id,
+                        'new_username' => $request->requested_username,
+                    ]);
+                }
+                break;
+            case 'Approved':
+                if ($request->for_nickname) {
+                    AuditLogger::log('user.nickname_request_approved', [
+                        'user_id'      => $request->user_id,
+                        'old_nickname' => $this->oldNickname ?: null,
+                        'new_nickname' => $request->requested_username ?: null,
+                    ]);
+                } else {
+                    AuditLogger::log('user.username_request_approved', [
+                        'user_id'      => $request->user_id,
+                        'old_username' => $this->oldUsername,
+                        'new_username' => $request->requested_username,
+                    ]);
+                }
+                break;
+            case 'Rejected':
+                if ($request->for_nickname) {
+                    AuditLogger::log('user.nickname_request_rejected', [
+                        'user_id'      => $request->user_id,
+                        'new_nickname' => $request->requested_username ?: null,
+                        'reason'       => $request->reason,
+                    ]);
+                } else {
+                    AuditLogger::log('user.username_request_rejected', [
+                        'user_id'      => $request->user_id,
+                        'new_username' => $request->requested_username,
+                        'reason'       => $request->reason,
+                    ]);
+                }
+                break;
+        }
+    }
+}

--- a/tests/integration/AuditTest.php
+++ b/tests/integration/AuditTest.php
@@ -136,8 +136,6 @@ class AuditTest extends TestCase
             'new_username' => 'user33',
         ], $log->payload);
         $this->assertEquals('127.0.0.1', $log->ip_address);
-
-        $this->assertNull(AuditLog::query()->where('action', 'user.username_changed')->first());
     }
 
     #[Test]
@@ -167,8 +165,6 @@ class AuditTest extends TestCase
             'new_nickname' => 'user33',
         ], $log->payload);
         $this->assertEquals('127.0.0.1', $log->ip_address);
-
-        $this->assertNull(AuditLog::query()->where('action', 'user.nickname_changed')->first());
     }
 
     #[Test]

--- a/tests/integration/AuditTest.php
+++ b/tests/integration/AuditTest.php
@@ -54,8 +54,10 @@ class AuditTest extends TestCase
             'authenticatedAs' => 1,
             'json'            => [
                 'data' => [
+                    'type'       => 'username-requests',
                     'attributes' => [
-                        'username' => 'admin2',
+                        'requestedUsername' => 'admin2',
+                        'forNickname'       => false,
                     ],
                 ],
                 'meta' => [
@@ -83,9 +85,10 @@ class AuditTest extends TestCase
             'authenticatedAs' => 1,
             'json'            => [
                 'data' => [
+                    'type'       => 'username-requests',
                     'attributes' => [
-                        'username'    => 'admin2',
-                        'forNickname' => true,
+                        'requestedUsername' => 'admin2',
+                        'forNickname'       => true,
                     ],
                 ],
                 'meta' => [
@@ -113,8 +116,10 @@ class AuditTest extends TestCase
             'authenticatedAs' => 1,
             'json'            => [
                 'data' => [
+                    'type'       => 'username-requests',
+                    'id'         => '1',
                     'attributes' => [
-                        'action' => 'Approved',
+                        'status' => 'Approved',
                     ],
                 ],
             ],
@@ -142,8 +147,10 @@ class AuditTest extends TestCase
             'authenticatedAs' => 1,
             'json'            => [
                 'data' => [
+                    'type'       => 'username-requests',
+                    'id'         => '2',
                     'attributes' => [
-                        'action' => 'Approved',
+                        'status' => 'Approved',
                     ],
                 ],
             ],
@@ -171,8 +178,10 @@ class AuditTest extends TestCase
             'authenticatedAs' => 1,
             'json'            => [
                 'data' => [
+                    'type'       => 'username-requests',
+                    'id'         => '1',
                     'attributes' => [
-                        'action' => 'Rejected',
+                        'status' => 'Rejected',
                         'reason' => 'because',
                     ],
                 ],
@@ -199,8 +208,10 @@ class AuditTest extends TestCase
             'authenticatedAs' => 1,
             'json'            => [
                 'data' => [
+                    'type'       => 'username-requests',
+                    'id'         => '2',
                     'attributes' => [
-                        'action' => 'Rejected',
+                        'status' => 'Rejected',
                         'reason' => 'because',
                     ],
                 ],

--- a/tests/integration/AuditTest.php
+++ b/tests/integration/AuditTest.php
@@ -41,8 +41,8 @@ class AuditTest extends TestCase
                 ],
             ],
             'username_requests' => [
-                ['id' => 1, 'user_id' => 3, 'requested_username' => 'user33', 'status' => 'Sent'],
-                ['id' => 2, 'user_id' => 3, 'requested_username' => 'user33', 'status' => 'Sent', 'for_nickname' => true],
+                ['id' => 1, 'user_id' => 3, 'requested_username' => 'user33', 'status' => 'Sent', 'created_at' => '2021-01-01 00:00:00'],
+                ['id' => 2, 'user_id' => 3, 'requested_username' => 'user33', 'status' => 'Sent', 'for_nickname' => true, 'created_at' => '2021-01-01 00:00:00'],
             ],
         ]);
     }

--- a/tests/integration/AuditTest.php
+++ b/tests/integration/AuditTest.php
@@ -1,0 +1,222 @@
+<?php
+
+/*
+ * This file is part of fof/username-request.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\UserRequest\Tests\integration;
+
+use Flarum\Audit\AuditLog;
+use Flarum\Audit\AuditLogger;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class AuditTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Lifecycle events fired outside the test transaction shouldn't create stray entries.
+        AuditLogger::$testMode = true;
+
+        $this->extension('flarum-audit', 'fof-username-request', 'flarum-nicknames');
+
+        $this->prepareDatabase([
+            'audit_log' => [],
+            User::class => [
+                [
+                    'id'       => 3,
+                    'username' => 'user3',
+                    'email'    => 'user3@example.com',
+                ],
+            ],
+            'username_requests' => [
+                ['id' => 1, 'user_id' => 3, 'requested_username' => 'user33', 'status' => 'Sent'],
+                ['id' => 2, 'user_id' => 3, 'requested_username' => 'user33', 'status' => 'Sent', 'for_nickname' => true],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function createUsername()
+    {
+        $response = $this->send($this->request('POST', '/api/username-requests', [
+            'authenticatedAs' => 1,
+            'json'            => [
+                'data' => [
+                    'attributes' => [
+                        'username' => 'admin2',
+                    ],
+                ],
+                'meta' => [
+                    'password' => 'password',
+                ],
+            ],
+        ]));
+
+        $this->assertEquals(201, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $log = AuditLog::query()->where('action', 'user.username_requested')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'user_id'      => 1,
+            'new_username' => 'admin2',
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+    }
+
+    #[Test]
+    public function createNickname()
+    {
+        $response = $this->send($this->request('POST', '/api/username-requests', [
+            'authenticatedAs' => 1,
+            'json'            => [
+                'data' => [
+                    'attributes' => [
+                        'username'    => 'admin2',
+                        'forNickname' => true,
+                    ],
+                ],
+                'meta' => [
+                    'password' => 'password',
+                ],
+            ],
+        ]));
+
+        $this->assertEquals(201, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $log = AuditLog::query()->where('action', 'user.nickname_requested')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'user_id'      => 1,
+            'new_nickname' => 'admin2',
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+    }
+
+    #[Test]
+    public function approveUsername()
+    {
+        $response = $this->send($this->request('PATCH', '/api/username-requests/1', [
+            'authenticatedAs' => 1,
+            'json'            => [
+                'data' => [
+                    'attributes' => [
+                        'action' => 'Approved',
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $log = AuditLog::query()->where('action', 'user.username_request_approved')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'user_id'      => 3,
+            'old_username' => 'user3',
+            'new_username' => 'user33',
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+
+        $this->assertNull(AuditLog::query()->where('action', 'user.username_changed')->first());
+    }
+
+    #[Test]
+    public function approveNickname()
+    {
+        $response = $this->send($this->request('PATCH', '/api/username-requests/2', [
+            'authenticatedAs' => 1,
+            'json'            => [
+                'data' => [
+                    'attributes' => [
+                        'action' => 'Approved',
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $log = AuditLog::query()->where('action', 'user.nickname_request_approved')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'user_id'      => 3,
+            'old_nickname' => null,
+            'new_nickname' => 'user33',
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+
+        $this->assertNull(AuditLog::query()->where('action', 'user.nickname_changed')->first());
+    }
+
+    #[Test]
+    public function rejectUsername()
+    {
+        $response = $this->send($this->request('PATCH', '/api/username-requests/1', [
+            'authenticatedAs' => 1,
+            'json'            => [
+                'data' => [
+                    'attributes' => [
+                        'action' => 'Rejected',
+                        'reason' => 'because',
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $log = AuditLog::query()->where('action', 'user.username_request_rejected')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'user_id'      => 3,
+            'new_username' => 'user33',
+            'reason'       => 'because',
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+    }
+
+    #[Test]
+    public function rejectNickname()
+    {
+        $response = $this->send($this->request('PATCH', '/api/username-requests/2', [
+            'authenticatedAs' => 1,
+            'json'            => [
+                'data' => [
+                    'attributes' => [
+                        'action' => 'Rejected',
+                        'reason' => 'because',
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $log = AuditLog::query()->where('action', 'user.nickname_request_rejected')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'user_id'      => 3,
+            'new_nickname' => 'user33',
+            'reason'       => 'because',
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+    }
+}


### PR DESCRIPTION
Adds an optional `flarum/audit` integration, moved out of `flarum/audit` where it was previously bundled. Mirrors how `flarum/suspend` ships its own audit integration: a `Conditional` on `flarum-audit` using the public `Flarum\Audit\Extend\Audit` extender, the log labels shipped under the `flarum-audit.lib.browser.*` locale namespace, and an `AuditTest` covering it.

`flarum/audit` is added to `require-dev` only — at runtime it is an optional dependency (the integration is a no-op unless flarum-audit is enabled).

Companion to flarum/framework#4807, which removes this integration from `flarum/audit`. To avoid duplicate logging, these should be released together.